### PR TITLE
Make search mode a top-level flag

### DIFF
--- a/lib/Git/Vogue.hs
+++ b/lib/Git/Vogue.hs
@@ -35,6 +35,13 @@ import           Git.Vogue.Plugins
 import           Git.Vogue.Types
 import           Paths_git_vogue
 
+-- | Options parsed from the command-line.
+data VogueOptions = Options
+    { optSearch  :: SearchMode
+    , optCommand :: VogueCommand
+    }
+  deriving (Eq, Show)
+
 -- | Commands, with parameters, to be executed.
 data VogueCommand
     -- | Add git-vogue support to a git repository.
@@ -43,14 +50,10 @@ data VogueCommand
     | CmdVerify
     -- | List the plugins that git-vogue knows about.
     | CmdList
-    -- | Run check plugins on changed files in a git repository.
-    | CmdRunCheckChanged
-    -- | Run check plugins on all files in a git repository.
-    | CmdRunCheckAll
-    -- | Run fix plugins on changed files in a git repository.
-    | CmdRunFixChanged
-    -- | Run fix plugins on all files in a git repository.
-    | CmdRunFixAll
+    -- | Run check plugins on files in a git repository.
+    | CmdRunCheck
+    -- | Run fix plugins on files in a git repository.
+    | CmdRunFix
   deriving (Eq, Show)
 
 -- | Plugins that git-vogue knows about.
@@ -71,14 +74,13 @@ runVogue ps (Vogue act) = runReaderT act ps
 runCommand
     :: (MonadIO m, Functor m)
     => VogueCommand
+    -> SearchMode
     -> Vogue m ()
-runCommand CmdInit{..}        = runWithRepoPath (gitAddHook templatePath)
-runCommand CmdVerify          = runWithRepoPath (gitCheckHook runsVogue)
-runCommand CmdList            = gitListHook
-runCommand CmdRunCheckChanged = runCheck FindChanged
-runCommand CmdRunCheckAll     = runCheck FindAll
-runCommand CmdRunFixChanged   = runFix FindChanged
-runCommand CmdRunFixAll       = runFix FindAll
+runCommand CmdInit{..} _ = runWithRepoPath (gitAddHook templatePath)
+runCommand CmdVerify   _ = runWithRepoPath (gitCheckHook runsVogue)
+runCommand CmdList     _ = gitListHook
+runCommand CmdRunCheck search = runCheck search
+runCommand CmdRunFix   search = runFix search
 
 -- | Try to fix the broken things. We first do one pass to check what's broken,
 -- then only run fix on those.

--- a/lib/Git/Vogue/Types.hs
+++ b/lib/Git/Vogue/Types.hs
@@ -41,6 +41,7 @@ newtype PluginName = PluginName {
 -- | We want the flexibility of just checking changed files, or maybe checking
 -- all of them.
 data SearchMode = FindAll | FindChanged
+  deriving (Eq, Show)
 
 -- | An implementation of a "runner" of plugins. Mostly for easy testing.
 data PluginExecutorImpl m = PluginExecutorImpl{

--- a/src/git-vogue.hs
+++ b/src/git-vogue.hs
@@ -29,16 +29,16 @@ optionsParser = subparser
                 "Check git-vogue support is all legit"
     <> pCommand "check"
                 CmdRunCheckChanged
-                "Run check plugins on all files in a git repo"
+                "Run check plugins on changed files in a git repo"
     <> pCommand "check-all"
                 CmdRunCheckAll
-                "Run fix plugins on a git repo"
+                "Run check plugins on all files in a git repo"
     <> pCommand "fix"
                 CmdRunFixChanged
-                "Run fix plugins on a git repo"
+                "Run fix plugins on changed files a git repo"
     <> pCommand "fix-all"
                 CmdRunFixAll
-                "Run fix plugins on a git repo"
+                "Run fix plugins on all files in a git repo"
     )
   where
     pInit = CmdInit <$> option (Just <$> readerAsk)

--- a/src/git-vogue.hs
+++ b/src/git-vogue.hs
@@ -19,26 +19,29 @@ import           Git.Vogue.Types
 import           Common
 import qualified Paths_git_vogue           as Paths
 
--- | Parse command line options.
-optionsParser :: Parser VogueCommand
-optionsParser = subparser
+-- | Parse command-line options.
+optionsParser :: Parser VogueOptions
+optionsParser = Options
+    <$> flag FindChanged FindAll
+        (  long "all"
+        <> short 'A'
+        <> help "Apply to all files, not just changed files."
+        )
+    <*> commandParser
+
+commandParser :: Parser VogueCommand
+commandParser = subparser
     ( command "init" (info pInit
         (progDesc "Initialise git-vogue support in a git repo"))
     <> pCommand "verify"
                 CmdVerify
                 "Check git-vogue support is all legit"
     <> pCommand "check"
-                CmdRunCheckChanged
-                "Run check plugins on changed files in a git repo"
-    <> pCommand "check-all"
-                CmdRunCheckAll
-                "Run check plugins on all files in a git repo"
+                CmdRunCheck
+                "Run check plugins on files in a git repo"
     <> pCommand "fix"
-                CmdRunFixChanged
-                "Run fix plugins on changed files a git repo"
-    <> pCommand "fix-all"
-                CmdRunFixAll
-                "Run fix plugins on all files in a git repo"
+                CmdRunFix
+                "Run fix plugins on files a git repo"
     )
   where
     pInit = CmdInit <$> option (Just <$> readerAsk)
@@ -76,9 +79,9 @@ discoverPlugins = do
 -- | Parse the command line and run the command.
 main :: IO ()
 main = do
-  cmd <- execParser opts
+  opt <- execParser opts
   plugins <- discoverPlugins
-  runVogue plugins (runCommand cmd)
+  runVogue plugins (runCommand (optCommand opt) (optSearch opt))
   where
     opts = info (helper <*> optionsParser)
       ( fullDesc


### PR DESCRIPTION
````
git-vogue - git integration for fashionable Haskell

Usage: git-vogue [-A|--all] COMMAND
  Make your Haskell git repository fashionable

Available options:
  -h,--help                Show this help text
  -A,--all                 Apply to all files, not just changed files.

Available commands:
  init                     Initialise git-vogue support in a git repo
  verify                   Check git-vogue support is all legit
  plugins                  List installed plugins.
  check                    Run check plugins on files in a git repo
  fix                      Run fix plugins on files a git repo
````