### PR TITLE
Disable plugins in git-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,21 @@ auto-fixing is stylish-haskell.
 Running `git-vogue plugins` will show you the libexec directory in which
 git-vogue will discover plugins.
 
-Should one or more plugins annoy you, you may disable it by setting it
+Should one or more plugins annoy you, you may disable it globally by setting it
 non-executable:
 
 ```bash
 chmod -x .cabal/libexec/git-vogue/git-vogue-stylish
 ```
+
+Alternatively you can disable plugins on a per-repository, per-user, or
+per-system basis by adding the file name to the `vogue.disable` key in your git
+configuration:
+
+````bash
+git config --local --add vogue.disable git-vogue-a-plugin
+git config --global --add vogue.disable git-vogue-another-plugin
+````
 
 A more sophisticated interface to plugin manipulation is planned.
 

--- a/lib/Git/Vogue.hs
+++ b/lib/Git/Vogue.hs
@@ -18,6 +18,7 @@
 module Git.Vogue where
 
 import           Control.Applicative
+import           Control.Exception
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
@@ -190,3 +191,12 @@ listPlugins = do
     liftIO .  putStr
          $  "git-vogue knows about the following plugins:\n\n"
          <> unlines (fmap (('\t':) . unPlugin) plugins)
+
+-- | Get list of disabled plugins from git configuration.
+disabledPlugins
+    :: (Monad m, Functor m, MonadIO m)
+    => m [String]
+disabledPlugins = lines <$> liftIO (readConfig `catch` none)
+  where
+    readConfig = readProcess "git" ["config", "--get-all", "vogue.disable"] ""
+    none (SomeException _) = return []


### PR DESCRIPTION
Add a list of disabled plugins to the git configuration system; plugins with these names will be ignored when running check and fix.

````bash
$ git-vogue plugins
git-vogue looks for plugins in:

	/.../.cabal-sandbox/libexec/git-vogue

git-vogue knows about the following plugins:

	/.../.cabal-sandbox/libexec/git-vogue/git-vogue-hlint
	/.../.cabal-sandbox/libexec/git-vogue/git-vogue-stylish
	/.../.cabal-sandbox/libexec/git-vogue/git-vogue-ghc-mod
	/.../.cabal-sandbox/libexec/git-vogue/git-vogue-cabal

$ git config --add vogue.disable git-vogue-cabal
$ git-vogue plugins
git-vogue looks for plugins in:

	/.../.cabal-sandbox/libexec/git-vogue

git-vogue knows about the following plugins:

	/.../.cabal-sandbox/libexec/git-vogue/git-vogue-hlint
	/.../.cabal-sandbox/libexec/git-vogue/git-vogue-stylish
	/.../.cabal-sandbox/libexec/git-vogue/git-vogue-ghc-mod
````