### PR TITLE
Abstract out some traversal stuff, making output consistent.

### DIFF
--- a/src/git-vogue-hlint.hs
+++ b/src/git-vogue-hlint.hs
@@ -14,19 +14,19 @@
 module Main where
 
 import           Control.Applicative
+import           Control.Monad
 import           Data.Bifunctor
-import           Data.Foldable                       (concat)
-import           Data.List                           hiding (concat)
+import           Data.Foldable
+import           Data.List                           hiding (and, concat)
 import           Data.Monoid
 import           Data.Traversable
 import           Git.Vogue.PluginCommon
 import           Language.Haskell.Exts.SrcLoc
 import           Language.Haskell.HLint3
 import           Language.Preprocessor.Cpphs
-import           Prelude                             hiding (concat)
+import           Prelude                             hiding (and, concat)
 import           System.Directory
 import           System.Exit
-import           System.FilePath
 
 #ifndef GPL_SCARES_ME
 import           Language.Haskell.HsColour.Colourise
@@ -41,33 +41,28 @@ main =
   where
     f CmdName  = putStrLn "hlint"
     f (CmdCheck check_fs all_fs) = do
-        cwd <- getCurrentDirectory  >>= canonicalizePath
         -- Traverse the files, parsing and processing as we go for efficiency
-        rs <- forWithKey (hsProjects check_fs all_fs) $ \dir fs -> do
+        rs <- forProjects (hsProjects check_fs all_fs) $ \fs -> do
             let hss = filter (isSuffixOf ".hs") fs
-            let pdir = "." </> dir
-            putStrLn $ "Checking " <> pdir
-                     <> " (" <> show (length hss) <> " files)"
-            setCurrentDirectory pdir
 
             (flags, classify, hint) <- autoSettings'
             -- Cpphs is off by default
             let flags' = flags { cppFlags = Cpphs defaultCpphsOptions }
 
 
-            x <- for hss $ \file ->
+            parsed <- for hss $ \file ->
                 process classify hint <$> parseModuleEx flags' file Nothing
-            setCurrentDirectory cwd
-            return x
 
-        let parsed = concat rs
-        let ideas = concat [ x | Right x <- parsed ]
-        let errors = [ x | Left x <- parsed ]
-        let out = unlines errors <> "\n" <> ideas
+            let ideas = concat [ x | Right x <- parsed ]
+            let errors = [ x | Left x <- parsed ]
+            let out = unlines errors <> "\n" <> ideas
 
-        if null ideas && null errors
-        then exitSuccess
-        else putStrLn out >> exitFailure
+            let ok = null ideas && null errors
+            unless ok (putStrLn out)
+            putStrLn $ "Checked " <> show (length hss) <> " file(s)"
+            return ok
+
+        unless (and rs) exitFailure
       where
         process classify hint =
             bimap (\x -> parseErrorMessage x <> show (parseErrorLocation x))


### PR DESCRIPTION
Three plugins were doing the exact same thing with changing directories and
working on the inner files. This was abstracted so that we can pretty up the
output at some point and add smarts.