### PR TITLE
Lose list-tries dependency.

### DIFF
--- a/git-vogue.cabal
+++ b/git-vogue.cabal
@@ -37,7 +37,6 @@ library
                      , filepath
                      , process
                      , containers
-                     , list-tries
                      , formatting
                      , split
                      , text

--- a/tests/unit.hs
+++ b/tests/unit.hs
@@ -46,7 +46,7 @@ main = do
                 let nested = ["a.cabal", "a.hs", "b/b.cabal", "b/b.hs"]
                 join hsProjects nested `shouldBe`
                     fromList [ ("",["a.cabal","a.hs"])
-                             , ("b/",["b.hs","b.cabal"]) ]
+                             , ("b/",["b.cabal", "b.hs"]) ]
 
 testLEDiscovery :: FilePath -> PluginDiscoverer IO -> Spec
 testLEDiscovery fixtures PluginDiscoverer{..} = do


### PR DESCRIPTION
We were using tries to do some sub-project finding logic. This was relatively
trivial to replace with a fold and some (at least quadratic) list manipulation.

This isn't performance critical code and list-tries has trouble with both
stackage and ghc 7.10.