### PR TITLE
Remove dependencies pakunused reports as redundant

### DIFF
--- a/git-vogue.cabal
+++ b/git-vogue.cabal
@@ -32,33 +32,25 @@ library
                        Git.Vogue.PluginCommon
   other-modules:       Paths_git_vogue
   build-depends:       base >=4.6 && <5
+                     , containers
                      , directory
                      , filepath
-                     , process
-                     , containers
                      , formatting
+                     , optparse-applicative >= 0.11
+                     , process
                      , split
                      , text
-                     , optparse-applicative >= 0.11
                      , transformers
-                     , mtl
                      , unix
-                       -- To fix depedencies
-                     , hlint           >= 1.9.13 && < 1.10
-                     , stylish-haskell >= 0.5.11 && < 0.5.12
-                     , ghc-mod         >= 5.2    && < 5.3
 
 executable git-vogue
   default-language:    Haskell2010
   hs-source-dirs:      src
   main-is:             git-vogue.hs
   build-depends:       base
-                     , filepath
-                     , directory
-                     , text
                      , git-vogue
                      , optparse-applicative
-                     , split
+                     , text
 
 executable git-vogue-cabal
   default-language:    Haskell2010
@@ -66,26 +58,20 @@ executable git-vogue-cabal
   main-is:             git-vogue-cabal.hs
   build-depends:       base
                      , Cabal
-                     , containers
                      , git-vogue
-                     , directory
-                     , filepath
-                     , process
 
 executable git-vogue-hlint
   default-language:    Haskell2010
   hs-source-dirs:      src
   main-is:             git-vogue-hlint.hs
   build-depends:       base
-                     , directory
-                     , filepath
-                     , hlint
-                     , cpphs
                      , bifunctors
-                     , haskell-src-exts
+                     , cpphs
+                     , directory
                      , git-vogue
+                     , haskell-src-exts
+                     , hlint           >= 1.9.13 && < 1.10
                      , hscolour
-                     , process
   if !flag(gpl)
         cpp-options: -DGPL_SCARES_ME
 
@@ -95,26 +81,17 @@ executable git-vogue-stylish
   main-is:             git-vogue-stylish.hs
   build-depends:       base
                      , Diff
-                     , directory
-                     , filepath
                      , git-vogue
-                     , process
                      , strict
-                     , stylish-haskell
+                     , stylish-haskell >= 0.5.11 && < 0.5.12
 
 executable git-vogue-ghc-mod
   default-language:    Haskell2010
   hs-source-dirs:      src
   main-is:             git-vogue-ghc-mod.hs
   build-depends:       base
-                     , Diff
-                     , directory
-                     , containers
-                     , filepath
+                     , ghc-mod         >= 5.2    && < 5.3
                      , git-vogue
-                     , process
-                     , strict
-                     , ghc-mod
 
 test-suite unit
   type:                exitcode-stdio-1.0
@@ -122,14 +99,12 @@ test-suite unit
   hs-source-dirs:      tests
   main-is:             unit.hs
   build-depends:       base
+                     , containers
                      , directory
                      , filepath
-                     , containers
                      , git-vogue
                      , hspec
-                     , temporary
                      , process
-                     , transformers
-                     , unix
+                     , temporary
 
 -- vim: set tabstop=21 expandtab:


### PR DESCRIPTION
I started playing with packunused -- it's a little bit awkward to use, isn't it?

I have done the needful to make it happy about git-vogue.

And also sorted the dependencies. Can we try to do this as a matter of course please?